### PR TITLE
Fix node-gyp updates to 8.4.1 as latest version breaks build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "http": "0.0.0",
-    "node-gyp": "",
+    "node-gyp": "8.4.1",
     "path": "^0.12.7",
     "websocket": "^1.0.25"
   },


### PR DESCRIPTION
Tried to run the latest gzweb build today and it broke with the following:
```
#20 32.37                  from /root/gzweb/tools/gzcoarse.cc:18:
#20 32.37 /usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 8 and 107 bytes into a destination of size 100
#20 32.37    67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
#20 32.37       |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#20 32.37    68 |        __bos (__s), __fmt, __va_arg_pack ());
#20 32.37       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#20 33.56 [100%] Linking CXX executable gzcoarse
#20 33.96 [100%] Built target gzcoarse
#20 34.12 gyp ERR! UNCAUGHT EXCEPTION 
#20 34.12 gyp ERR! stack TypeError: Object.fromEntries is not a function
#20 34.12 gyp ERR! stack     at Object.<anonymous> (/root/gzweb/node_modules/@npmcli/fs/lib/fs.js:6:23)
#20 34.12 gyp ERR! stack     at Module._compile (internal/modules/cjs/loader.js:778:30)
#20 34.12 gyp ERR! stack     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
#20 34.12 gyp ERR! stack     at Module.load (internal/modules/cjs/loader.js:653:32)
#20 34.12 gyp ERR! stack     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
#20 34.12 gyp ERR! stack     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
#20 34.12 gyp ERR! stack     at Module.require (internal/modules/cjs/loader.js:692:17)
#20 34.12 gyp ERR! stack     at require (internal/modules/cjs/helpers.js:25:18)
#20 34.12 gyp ERR! stack     at Object.<anonymous> (/root/gzweb/node_modules/@npmcli/fs/lib/index.js:2:6)
#20 34.12 gyp ERR! stack     at Module._compile (internal/modules/cjs/loader.js:778:30)
#20 34.12 gyp ERR! stack     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
#20 34.12 gyp ERR! stack     at Module.load (internal/modules/cjs/loader.js:653:32)
#20 34.12 gyp ERR! stack     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
#20 34.12 gyp ERR! stack     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
#20 34.12 gyp ERR! stack     at Module.require (internal/modules/cjs/loader.js:692:17)
#20 34.12 gyp ERR! stack     at require (internal/modules/cjs/helpers.js:25:18)
#20 34.12 gyp ERR! System Linux 4.19.128-microsoft-standard
#20 34.13 gyp ERR! command "/root/.nvm/versions/node/v10.24.1/bin/node" "/root/gzweb/node_modules/.bin/node-gyp" "configure"
#20 34.13 gyp ERR! cwd /root/gzweb/gzbridge
#20 34.13 gyp ERR! node -v v10.24.1
#20 34.13 gyp ERR! node-gyp -v v9.0.0
#20 34.13 gyp ERR! Node-gyp failed to build your package.
#20 34.13 gyp ERR! Try to update npm and/or node-gyp and if it does not help file an issue with the package author.
#20 34.13 sed: can't read build/gzbridge.target.mk: No such file or directory
#20 34.20 gyp ERR! build error 
#20 34.20 gyp ERR! stack Error: You must run `node-gyp configure` first!
#20 34.20 gyp ERR! stack     at ReadFileContext.<anonymous> (/root/gzweb/node_modules/node-gyp/lib/build.js:43:20)
#20 34.20 gyp ERR! stack     at ReadFileContext.callback (/root/gzweb/node_modules/graceful-fs/graceful-fs.js:123:16)
#20 34.20 gyp ERR! stack     at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:237:13)
#20 34.20 gyp ERR! System Linux 4.19.128-microsoft-standard
#20 34.20 gyp ERR! command "/root/.nvm/versions/node/v10.24.1/bin/node" "/root/gzweb/node_modules/.bin/node-gyp" "build" "-d"
#20 34.20 gyp ERR! cwd /root/gzweb/gzbridge
#20 34.20 gyp ERR! node -v v10.24.1
#20 34.20 gyp ERR! node-gyp -v v9.0.0
#20 34.20 gyp ERR! not ok 
#20 34.20 There are node-gyp build errors, exiting.
#20 34.20 npm ERR! code ELIFECYCLE
#20 34.20 npm ERR! errno 1
#20 34.20 npm ERR! gzweb@1.3.0 deploy: `./deploy.sh "-m" "local"`
#20 34.20 npm ERR! Exit status 1
#20 34.20 npm ERR! 
#20 34.20 npm ERR! Failed at the gzweb@1.3.0 deploy script.
#20 34.20 npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
#20 34.22 
#20 34.22 npm ERR! A complete log of this run can be found in:
#20 34.22 npm ERR!     /root/.npm/_logs/2022-03-25T10_58_51_184Z-debug.log
------
error: failed to solve: executor failed running [/usr/bin/bash -c source /ros.env     && source /root/.nvm/nvm.sh     && cd ${GZWEB_WS} && npm run deploy --- -m local]: exit code: 1
Makefile:9: recipe for target 'core' failed
make[1]: *** [core] Error 1
make[1]: Leaving directory '/home/mickey/Documents/starling/ProjectStarling/simulator/base'
Makefile:9: recipe for target 'px4' failed
```

If I updated npm version to 12 or 14 as per searching that error message, the build just fails in particular with the v8::Handle:
```
00 ../GZNode.hh:36:30: error: ‘v8::Handle’ has not been declared
#20 36.00    36 |     public: static void Init(v8::Handle<v8::Object> exports);
...
...
------
error: failed to solve: executor failed running [/usr/bin/bash -c source /ros.env     && source /root/.nvm/nvm.sh     && cd ${GZWEB_WS} && npm run deploy --- -m local]: exit code: 1
Makefile:9: recipe for target 'core' failed
make[1]: *** [core] Error 1
make[1]: Leaving directory '/home/mickey/Documents/starling/ProjectStarling/simulator/base'
Makefile:9: recipe for target 'px4' failed
make: *** [px4] Error 2
```

Therefore checking node-gyp, it looks like it only recently updated to v9.0.0 (https://www.npmjs.com/package/node-gyp/v/9.0.0). Which I think has updated its internal JS version such that its not compatible with gzweb or npm 10. 

So here we just fix the version of node-gyp. Have verified it works with the dockerfile (by sed-ding in the change)